### PR TITLE
Add channel filter and 4-column layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,35 +1,67 @@
 const SHEET_ENDPOINT = 'https://script.google.com/macros/s/AKfycby0wKSPUkCtTY9aXRZapXlrcbnkXERVpqWeDCGRXtzV9hRLX1uDicYasyMgzYRkt2c/exec';
 const SLACK_PROXY = 'https://script.google.com/macros/s/AKfycbzeVJHxItDkHk4zhzvq1KtaP4R31G3C4m7Mte7W5AnyCBl43AJPNSUKE5qOTgzSTivt/exec';
 
+let channelsData = [];
+
 async function getChannels() {
   try {
     const res = await fetch(SHEET_ENDPOINT);
     if (!res.ok) throw new Error('No se pudieron cargar los canales');
-    const data = await res.json();
-    renderChannels(data);
+    channelsData = await res.json();
+    filterChannels();
   } catch (error) {
     alert('Error al cargar los canales: ' + error.message);
   }
+}
+
+function filterChannels() {
+  const filter = document.getElementById('channelFilter').value;
+  let filtered = channelsData;
+  if (filter === 'slack') {
+    filtered = channelsData.filter(c => c.tipo === 'slack');
+  } else if (filter === 'telegram') {
+    filtered = channelsData.filter(c => c.tipo === 'telegram');
+  }
+  renderChannels(filtered);
 }
 
 function renderChannels(channels) {
   const list = document.getElementById('channelList');
   list.innerHTML = '';
 
+  const slackCol1 = document.createElement('div');
+  slackCol1.className = 'col-md-3';
+  const slackCol2 = document.createElement('div');
+  slackCol2.className = 'col-md-3';
+  const teleCol1 = document.createElement('div');
+  teleCol1.className = 'col-md-3';
+  const teleCol2 = document.createElement('div');
+  teleCol2.className = 'col-md-3';
+
+  let sIndex = 0;
+  let tIndex = 0;
+
   channels.forEach((channel, i) => {
-    const col = document.createElement('div');
-    col.className = 'col-md-6 mb-2';
-    col.innerHTML = `
-      <div class="form-check">
-        <input class="form-check-input channel-checkbox" type="checkbox"
-          value="${channel.id_canal_slack}" data-tipo="${channel.tipo}" id="check${i}">
-        <label class="form-check-label" for="check${i}">
-          ${channel.nombre} <span class="badge bg-secondary">${channel.tipo}</span>
-        </label>
-      </div>
+    const wrapper = document.createElement('div');
+    wrapper.className = 'form-check mb-2';
+    wrapper.innerHTML = `
+      <input class="form-check-input channel-checkbox" type="checkbox" value="${channel.id_canal_slack}" data-tipo="${channel.tipo}" id="check${i}">
+      <label class="form-check-label" for="check${i}">${channel.nombre}</label>
     `;
-    list.appendChild(col);
+
+    if (channel.tipo === 'slack') {
+      (sIndex % 2 === 0 ? slackCol1 : slackCol2).appendChild(wrapper);
+      sIndex++;
+    } else {
+      (tIndex % 2 === 0 ? teleCol1 : teleCol2).appendChild(wrapper);
+      tIndex++;
+    }
   });
+
+  list.appendChild(slackCol1);
+  list.appendChild(slackCol2);
+  list.appendChild(teleCol1);
+  list.appendChild(teleCol2);
 
   document.getElementById('selectAll').checked = false;
 }
@@ -84,6 +116,8 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('selectAll').addEventListener('change', e => {
     document.querySelectorAll('.channel-checkbox').forEach(cb => cb.checked = e.target.checked);
   });
+
+  document.getElementById('channelFilter').addEventListener('change', filterChannels);
 
   document.getElementById('sendBtn').addEventListener('click', sendMessages);
   getChannels();

--- a/index.html
+++ b/index.html
@@ -31,6 +31,14 @@
 
     <div class="mb-4">
       <h5>Seleccioná los canales:</h5>
+      <div class="mb-2">
+        <label for="channelFilter" class="form-label">Filtrar por plataforma</label>
+        <select id="channelFilter" class="form-select w-auto">
+          <option value="all">Todos</option>
+          <option value="slack">Slack</option>
+          <option value="telegram">Telegram</option>
+        </select>
+      </div>
       <div id="channelList" class="row"></div>
     </div>
 


### PR DESCRIPTION
## Summary
- add dropdown filter to select Slack or Telegram channels
- group channels into two Slack columns and two Telegram columns
- filter channels based on selected platform

## Testing
- `node -c app.js`
- `node -e "require('./app.js')"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68421118f0088326bf1f019f24821bd7